### PR TITLE
Add AWS GovCloud partition support

### DIFF
--- a/account-search.js
+++ b/account-search.js
@@ -11,12 +11,16 @@ function parseAccounts() {
     var accountReg = /(\d{12})/;
     var accountNum = accountName.match(accountReg)[1];
 
+    var partitionReg = /(arn:)([^:]+)/;
+    var accountArn = account.querySelector(".saml-radio").value;
+    var accountPartition = accountArn.match(partitionReg)[2];
+    
     // Find the roles
     var roles = account.querySelectorAll(".saml-role");
     for(var j = 0; j < roles.length; j++) {
       var roleName = roles.item(j).textContent.trim();
       accountRoles.push({
-        "id": `arn:aws:iam::${accountNum}:role/${roleName}`,
+        "id": `arn:${accountPartition}:iam::${accountNum}:role/${roleName}`,
         "text": `${accountName} - ${roleName}`,
         "accountNum": accountNum,
         "roleName": roleName,

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,10 @@
 
   "content_scripts": [
     {
-      "matches": ["https://signin.aws.amazon.com/saml"],
+      "matches": [
+        "https://signin.aws.amazon.com/saml",
+        "https://signin.amazonaws-us-gov.com/saml"
+      ],
       "js": [
         "jquery-3.4.1.slim.min.js",
         "popper.min.js",


### PR DESCRIPTION
Ref: "AWS Management Console with SAML" - https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/using-govcloud-endpoints.html

Tested successfully with both commercial (`aws`) and govcloud (`aws-us-gov`) AWS partitions.